### PR TITLE
Asus Zenbook Duo 2026 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Notes:
 
 ### Requirements
 
-- ASUS Zenbook Duo (USB vendor `0B05`, product `1B2C`)
+- ASUS Zenbook Duo (USB vendor `0B05`, product `1B2C`; the 2026 UX8407AA uses product `1CD7` and needs extra setup — see [Zenbook Duo 2026 (UX8407AA)](#asus-zenbook-duo-2026-ux8407aa))
 - Linux with GNOME on Wayland, KDE Plasma on Wayland, or Niri (tested with Fedora)
 - `systemd` for service management
 - GNOME: `gdctl` (part of `mutter`) for display configuration
@@ -220,6 +220,55 @@ cd ui-tauri-react
 npm install
 npm run dev
 ```
+
+## ASUS Zenbook Duo 2026 (UX8407AA)
+
+The 2026 model (Intel Core Ultra "Panther Lake", Intel Arc iGPU on the `xe` driver, keyboard USB ID `0b05:1cd7`) works with this project, but the stock kernel and firmware have several bugs that must be fixed first. Verified on CachyOS + KDE Plasma on Wayland with a patched 7.2-rc5 kernel. The kernel patches come from [zenbook-duo26-Ubuntu26.04](https://github.com/therealarnold666/zenbook-duo26-Ubuntu26.04) (an Ubuntu-targeted derivative of this project) — use its patches, but do not run its installer on non-Ubuntu distros; run this project's installer instead.
+
+This project detects the UX8407AA via DMI (`/sys/class/dmi/id/board_name`) and automatically compensates for its upside-down top panel in the KDE display backend, so no code changes are needed — only the system-level steps below.
+
+### 1. Kernel patches — keyboard-detach freeze and audio
+
+- **Detach freeze / bottom screen never re-enables**: the Port B C20 TCSS PHY loses its power ack when eDP-2 is toggled. Fix: DMI-gated patch `0001` (i915/xe shared display code) from the repo above.
+- **No audio** (`aplay -l` shows no cards): a ghost RT722 SoundWire device makes `sof_sdw` probing fail with `-EEXIST` (duplicate `SDW3-Playback-SimpleJack`). Fix: patch `0002` (adds UX8407AA to the SoundWire DMI ghost-device quirk table).
+
+Both apply cleanly to kernel 7.2-rc5. On Arch-based distros, append the patch files to your kernel PKGBUILD's `source` array (with `SKIP` checksums) and rebuild; then pin the patched kernel (e.g. `IgnorePkg` in `/etc/pacman.conf`) so an update does not replace it before the fixes land upstream.
+
+### 2. Kernel command line
+
+Add to your bootloader's kernel command line:
+
+```
+video=eDP-1:panel_orientation=upside_down xe.enable_psr=0 xe.enable_psr2_sel_fetch=0 xe.enable_panel_replay=0 xe.enable_dpcd_backlight=3
+```
+
+- `video=eDP-1:panel_orientation=upside_down` — the top panel is physically mounted 180° and there is no upstream DRM quirk yet; this fixes the console/LUKS-prompt orientation.
+- `xe.enable_psr=0 xe.enable_psr2_sel_fetch=0 xe.enable_panel_replay=0` — avoids PSR/panel-replay flicker and hangs on Panther Lake.
+- `xe.enable_dpcd_backlight=3` — enables brightness control (the default backlight path does not work on this panel).
+- Do **not** add `xe.enable_dsb=0` on the patched kernel: it forces a slow CPU display path and causes multi-blink flicker on wake from screen-off. It was only ever an interim mitigation for the detach freeze that patch `0001` fixes properly.
+
+### 3. Auto-rotation — ASUS ISH firmware
+
+The accelerometer sits behind the Intel ISH, and the mainline `ish_ptl.bin` firmware fails to load on this machine (`ISH loader: cmd 2 failed` in dmesg, no IIO devices). Fix: extract the ASUS-signed ISH firmware from ASUS's Windows "Intel Integrated Sensor Solution Driver" package and install it (compressed) as `/usr/lib/firmware/intel/ish/ish_ptl.bin.zst`, keeping a backup of the mainline blob. After a reboot, `accel_3d` appears under `/sys/bus/iio/devices/` and `iio-sensor-proxy` works.
+
+Note: linux-firmware package updates will restore the broken mainline blob — re-apply the ASUS blob after firmware updates (a pacman/apt post-transaction hook that compares and restores it automates this).
+
+### 4. Rotation settings (KDE)
+
+- Only the top panel (eDP-1) is mounted upside down; the app applies the per-panel 180° offset automatically on UX8407AA.
+- Set `"invertSensorRotation": true` in `~/.config/zenbook-duo/settings.json` (or toggle it in the Control Panel UI).
+- Set Screen Rotation to **Manual** for both screens in KDE System Settings → Display & Monitor. Otherwise KWin's own tablet-mode auto-rotate (which does not know about the flipped panel) fights this app whenever the keyboard is detached.
+- In the KDE session, eDP-1 showing as "Rotated 180°" in display settings is the correct resting state — KWin ignores the kernel `panel_orientation` quirk, so do not manually reset it to normal.
+
+### 5. Login screen orientation
+
+The greeter runs its own KWin instance, which also ignores the panel-orientation quirk, so the login screen appears upside down. Fix: once your session displays correctly, copy your display config into the greeter's home:
+
+```bash
+sudo install -Dm644 -o sddm -g sddm ~/.config/kwinoutputconfig.json /var/lib/sddm/.config/kwinoutputconfig.json
+```
+
+On installs using `plasmalogin` instead of SDDM (some CachyOS setups), use `/var/lib/plasmalogin/.config/kwinoutputconfig.json` owned by `plasmalogin:plasmalogin`.
 
 ## Fedora: “Nobara-like” setup helper
 

--- a/patches/ux8407aa/0001-ux8407aa-port-b-tcss-power-and-diagnostics.patch
+++ b/patches/ux8407aa/0001-ux8407aa-port-b-tcss-power-and-diagnostics.patch
@@ -1,0 +1,309 @@
+--- a/drivers/gpu/drm/i915/display/intel_display.c
++++ b/drivers/gpu/drm/i915/display/intel_display.c
+@@ -25,6 +25,8 @@
+  */
+ 
+ #include <linux/dma-resv.h>
++#include <linux/delay.h>
++#include <linux/dmi.h>
+ #include <linux/i2c.h>
+ #include <linux/input.h>
+ #include <linux/kernel.h>
+@@ -67,6 +69,7 @@
+ #include "intel_cursor.h"
+ #include "intel_cursor_regs.h"
+ #include "intel_cx0_phy.h"
++#include "intel_cx0_phy_regs.h"
+ #include "intel_ddi.h"
+ #include "intel_de.h"
+ #include "intel_display_driver.h"
+@@ -127,6 +130,7 @@
+ #include "intel_wm.h"
+ #include "skl_scaler.h"
+ #include "skl_universal_plane.h"
++#include "skl_universal_plane_regs.h"
+ #include "skl_watermark.h"
+ #include "vlv_dsi.h"
+ #include "vlv_dsi_pll.h"
+@@ -7279,6 +7283,19 @@
+ 		!intel_crtc_needs_modeset(new_crtc_state) &&
+ 		!intel_crtc_needs_fastset(new_crtc_state);
+ 
++	/*
++	 * Pipe B's DSB engine on the UX8407AA reaches the final cacheline but
++	 * never signals completion. The resulting 10 second atomic commit
++	 * timeout corrupts the eDP-2 teardown/re-enable sequence during the
++	 * GDM-to-user-session handoff. Keep the generic MMIO update path for
++	 * this pipe until the Panther Lake DSB erratum is understood.
++	 */
++	if (crtc->pipe == PIPE_B &&
++	    dmi_match(DMI_PRODUCT_NAME, "Zenbook Duo UX8407AA")) {
++		new_crtc_state->use_flipq = false;
++		new_crtc_state->use_dsb = false;
++	}
++
+ 	intel_color_prepare_commit(state, crtc);
+ }
+ 
+@@ -7415,11 +7432,150 @@
+ 			intel_pipedmc_dcb_enable(new_crtc_state->dsb_commit, crtc);
+ 
+ 		intel_dsb_interrupt(new_crtc_state->dsb_commit);
++
+ 	}
+ 
+ 	intel_dsb_finish(new_crtc_state->dsb_commit);
+ }
+ 
++/*
++ * Keep the generic flip wait behaviour, but capture the display interrupt
++ * state before the DSB cleanup masks the evidence from a stuck pipe.
++ */
++struct zenbook_pipe_snapshot {
++	u32 dsl;
++	u32 frame;
++	u32 transconf;
++	u32 ddi_func_ctl;
++	u32 plane_ctl;
++	u32 plane_surf;
++	u32 plane_surflive;
++	u32 port_clock_ctl;
++	u32 port_buf_ctl1;
++	u32 port_buf_ctl2;
++	u32 port_buf_ctl3;
++	u32 msgbus_timer_lane0;
++	u32 msgbus_timer_lane1;
++	u32 ddi_clk_valfreq;
++};
++
++static void zenbook_take_pipe_snapshot(struct intel_display *display,
++				       enum pipe pipe,
++				       struct zenbook_pipe_snapshot *snapshot)
++{
++	enum transcoder transcoder = (enum transcoder)pipe;
++	enum port port = pipe == PIPE_A ? PORT_A : PORT_B;
++
++	snapshot->dsl = intel_de_read(display, PIPEDSL(display, pipe));
++	snapshot->frame = intel_de_read(display,
++				       PIPE_FRMCOUNT_G4X(display, pipe));
++	snapshot->transconf = intel_de_read(display,
++					   TRANSCONF(display, transcoder));
++	snapshot->ddi_func_ctl = intel_de_read(display,
++					      TRANS_DDI_FUNC_CTL(display,
++								 transcoder));
++	snapshot->plane_ctl = intel_de_read(display,
++					   PLANE_CTL(pipe, PLANE_PRIMARY));
++	snapshot->plane_surf = intel_de_read(display,
++					    PLANE_SURF(pipe, PLANE_PRIMARY));
++	snapshot->plane_surflive = intel_de_read(display,
++						PLANE_SURFLIVE(pipe,
++							       PLANE_PRIMARY));
++	snapshot->port_clock_ctl = intel_de_read(display,
++						XELPDP_PORT_CLOCK_CTL(display,
++								    port));
++	snapshot->port_buf_ctl1 = intel_de_read(display,
++					       XELPDP_PORT_BUF_CTL1(display,
++								  port));
++	snapshot->port_buf_ctl2 = intel_de_read(display,
++					       XELPDP_PORT_BUF_CTL2(display,
++								  port));
++	snapshot->port_buf_ctl3 = intel_de_read(display,
++					       XELPDP_PORT_BUF_CTL3(display,
++								  port));
++	snapshot->msgbus_timer_lane0 = intel_de_read(display,
++						    XELPDP_PORT_MSGBUS_TIMER(display,
++									   port, 0));
++	snapshot->msgbus_timer_lane1 = intel_de_read(display,
++						    XELPDP_PORT_MSGBUS_TIMER(display,
++									   port, 1));
++	snapshot->ddi_clk_valfreq = intel_de_read(display,
++						 DDI_CLK_VALFREQ(port));
++}
++
++static void zenbook_dump_pipe_progress(struct intel_display *display)
++{
++	struct zenbook_pipe_snapshot a1, a2, b1, b2;
++
++	zenbook_take_pipe_snapshot(display, PIPE_A, &a1);
++	zenbook_take_pipe_snapshot(display, PIPE_B, &b1);
++	msleep(20);
++	zenbook_take_pipe_snapshot(display, PIPE_A, &a2);
++	zenbook_take_pipe_snapshot(display, PIPE_B, &b2);
++
++	drm_err(display->drm,
++		"UX8407AA pipe A progress: dsl %08x->%08x frame %08x->%08x transconf=%08x ddi=%08x plane ctl=%08x surf=%08x live=%08x\n",
++		a1.dsl, a2.dsl, a1.frame, a2.frame, a2.transconf,
++		a2.ddi_func_ctl, a2.plane_ctl, a2.plane_surf,
++		a2.plane_surflive);
++	drm_err(display->drm,
++		"UX8407AA pipe B progress: dsl %08x->%08x frame %08x->%08x transconf=%08x ddi=%08x plane ctl=%08x surf=%08x live=%08x\n",
++		b1.dsl, b2.dsl, b1.frame, b2.frame, b2.transconf,
++		b2.ddi_func_ctl, b2.plane_ctl, b2.plane_surf,
++		b2.plane_surflive);
++	drm_err(display->drm,
++		"UX8407AA PHY A: clock=%08x buf1=%08x buf2=%08x buf3=%08x msg0=%08x msg1=%08x valfreq=%08x\n",
++		a2.port_clock_ctl, a2.port_buf_ctl1, a2.port_buf_ctl2,
++		a2.port_buf_ctl3, a2.msgbus_timer_lane0,
++		a2.msgbus_timer_lane1, a2.ddi_clk_valfreq);
++	drm_err(display->drm,
++		"UX8407AA PHY B: clock=%08x buf1=%08x buf2=%08x buf3=%08x msg0=%08x msg1=%08x valfreq=%08x\n",
++		b2.port_clock_ctl, b2.port_buf_ctl1, b2.port_buf_ctl2,
++		b2.port_buf_ctl3, b2.msgbus_timer_lane0,
++		b2.msgbus_timer_lane1, b2.ddi_clk_valfreq);
++}
++
++static void intel_atomic_wait_for_flip_done(struct intel_atomic_state *state)
++{
++	struct intel_display *display = to_intel_display(state);
++	struct drm_crtc *base_crtc;
++	int i;
++
++	for (i = 0; i < display->drm->mode_config.num_crtc; i++) {
++		struct drm_crtc_commit *commit = state->base.crtcs[i].commit;
++		struct intel_crtc *crtc;
++		struct intel_crtc_state *crtc_state;
++		enum pipe pipe;
++		int ret;
++
++		base_crtc = state->base.crtcs[i].ptr;
++		if (!base_crtc || !commit)
++			continue;
++
++		ret = wait_for_completion_timeout(&commit->flip_done, 10 * HZ);
++		if (ret)
++			continue;
++
++		crtc = to_intel_crtc(base_crtc);
++		crtc_state = intel_atomic_get_new_crtc_state(state, crtc);
++		pipe = crtc->pipe;
++
++		drm_err(display->drm,
++			"[CRTC:%d:%s] flip_done timed out; pipe %c IRQ IIR=0x%08x IMR=0x%08x IER=0x%08x\\n",
++			base_crtc->base.id, base_crtc->name, pipe_name(pipe),
++			intel_de_read(display, GEN8_DE_PIPE_IIR(pipe)),
++			intel_de_read(display, GEN8_DE_PIPE_IMR(pipe)),
++			intel_de_read(display, GEN8_DE_PIPE_IER(pipe)));
++		if (pipe == PIPE_B &&
++		    dmi_match(DMI_PRODUCT_NAME, "Zenbook Duo UX8407AA"))
++			zenbook_dump_pipe_progress(display);
++		intel_crtc_state_dump(crtc_state, state, "flip_done timeout");
++	}
++
++	if (state->base.fake_commit)
++		complete_all(&state->base.fake_commit->flip_done);
++}
++
+ static void intel_atomic_commit_tail(struct intel_atomic_state *state)
+ {
+ 	struct intel_display *display = to_intel_display(state);
+@@ -7550,7 +7706,7 @@
+ 	 * - switch over to the vblank wait helper in the core after that since
+ 	 *   we don't need out special handling any more.
+ 	 */
+-	drm_atomic_helper_wait_for_flip_done(display->drm, &state->base);
++	intel_atomic_wait_for_flip_done(state);
+ 
+ 	for_each_new_intel_crtc_in_state(state, crtc, new_crtc_state) {
+ 		if (new_crtc_state->do_async_flip)
+--- a/drivers/gpu/drm/i915/display/intel_tc.c
++++ b/drivers/gpu/drm/i915/display/intel_tc.c
+@@ -1090,24 +1090,27 @@
+ 	}
+ }
+ 
+-static void __xelpdp_tc_phy_enable_tcss_power(struct intel_tc_port *tc, bool enable)
++void intel_tc_tcss_power_request(struct intel_encoder *encoder, bool enable)
+ {
+-	struct intel_display *display = to_intel_display(tc->dig_port);
+-	enum port port = tc->dig_port->base.port;
++	struct intel_display *display = to_intel_display(encoder);
++	enum port port = encoder->port;
+ 	intel_reg_t reg = XELPDP_PORT_BUF_CTL1(display, port);
+-	u32 val;
++	u32 val = intel_de_read(display, reg);
+ 
+-	assert_tc_cold_blocked(tc);
++	if (!!(val & XELPDP_TCSS_POWER_REQUEST) == enable)
++		return;
+ 
+ 	if (DISPLAY_VER(display) == 30)
+ 		xelpdp_tc_power_request_wa(display, enable);
+ 
+-	val = intel_de_read(display, reg);
+-	if (enable)
+-		val |= XELPDP_TCSS_POWER_REQUEST;
+-	else
+-		val &= ~XELPDP_TCSS_POWER_REQUEST;
+-	intel_de_write(display, reg, val);
++	intel_de_rmw(display, reg, XELPDP_TCSS_POWER_REQUEST,
++		     enable ? XELPDP_TCSS_POWER_REQUEST : 0);
++}
++
++static void __xelpdp_tc_phy_enable_tcss_power(struct intel_tc_port *tc, bool enable)
++{
++	assert_tc_cold_blocked(tc);
++	intel_tc_tcss_power_request(&tc->dig_port->base, enable);
+ }
+ 
+ static bool xelpdp_tc_phy_enable_tcss_power(struct intel_tc_port *tc, bool enable)
+--- a/drivers/gpu/drm/i915/display/intel_tc.h
++++ b/drivers/gpu/drm/i915/display/intel_tc.h
+@@ -88,6 +88,7 @@
+ bool intel_tc_port_handles_hpd_glitches(struct intel_digital_port *dig_port);
+ 
+ bool intel_tc_port_connected(struct intel_encoder *encoder);
++void intel_tc_tcss_power_request(struct intel_encoder *encoder, bool enable);
+ 
+ enum intel_tc_pin_assignment
+ intel_tc_port_get_pin_assignment(struct intel_digital_port *dig_port);
+--- a/drivers/gpu/drm/i915/display/intel_cx0_phy.c
++++ b/drivers/gpu/drm/i915/display/intel_cx0_phy.c
+@@ -5,6 +5,7 @@
+ 
+ #include <linux/log2.h>
+ #include <linux/math64.h>
++#include <linux/dmi.h>
+ 
+ #include <drm/drm_print.h>
+ 
+@@ -34,6 +35,18 @@
+ #define INTEL_CX0_LANE1		BIT(1)
+ #define INTEL_CX0_BOTH_LANES	(INTEL_CX0_LANE1 | INTEL_CX0_LANE0)
+ 
++static bool intel_cx0_is_ux8407aa_c20_edp_port_b(struct intel_encoder *encoder)
++{
++	struct intel_display *display = to_intel_display(encoder);
++
++	return display->platform.pantherlake &&
++	       encoder->type == INTEL_OUTPUT_EDP &&
++	       encoder->port == PORT_B &&
++	       !intel_encoder_is_c10phy(encoder) &&
++	       dmi_match(DMI_SYS_VENDOR, "ASUS") &&
++	       dmi_match(DMI_PRODUCT_NAME, "Zenbook Duo UX8407AA");
++}
++
+ bool intel_encoder_is_c10phy(struct intel_encoder *encoder)
+ {
+ 	struct intel_display *display = to_intel_display(encoder);
+@@ -3183,6 +3196,21 @@
+ 		port_clock = intel_c20pll_calc_port_clock(&pll_state->c20);
+ 
+ 	/*
++	 * UX8407AA wires its second internal panel to PTL Port B's C20
++	 * Type-C PHY. Keep the TCSS PHY power request asserted while this
++	 * dedicated eDP path is in use; otherwise the PLL/refclk ACKs can
++	 * disappear even though the display clock requests remain asserted.
++	 */
++	if (intel_cx0_is_ux8407aa_c20_edp_port_b(encoder)) {
++		intel_tc_tcss_power_request(encoder, true);
++		if (intel_de_wait_for_set_ms(display,
++					 XELPDP_PORT_BUF_CTL1(display, encoder->port),
++					 XELPDP_TCSS_POWER_STATE, 5))
++			drm_warn(display->drm,
++				 "UX8407AA Port B TCSS power request was not acknowledged\n");
++	}
++
++	/*
+ 	 * Lane reversal is never used in DP-alt mode, in that case the
+ 	 * corresponding lane swapping (based on the TypeC cable flip state
+ 	 * for instance) is handled automatically by the HW via a TCSS mux.

--- a/patches/ux8407aa/0002-ux8407aa-ignore-ghost-rt722.patch
+++ b/patches/ux8407aa/0002-ux8407aa-ignore-ghost-rt722.patch
@@ -1,0 +1,16 @@
+--- a/drivers/soundwire/dmi-quirks.c
++++ b/drivers/soundwire/dmi-quirks.c
+@@ -148,6 +148,13 @@ static const struct dmi_system_id adr_remap_quirk_table[] = {
+ 		},
+ 		.driver_data = (void *)ghost_realtek,
+ 	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUS"),
++			DMI_MATCH(DMI_BOARD_NAME, "UX8407AA"),
++		},
++		.driver_data = (void *)ghost_realtek,
++	},
+ 	{
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),

--- a/ui-tauri-react/src-tauri/src/hardware/display_layout/kde.rs
+++ b/ui-tauri-react/src-tauri/src/hardware/display_layout/kde.rs
@@ -165,17 +165,7 @@ fn kde_rotation_token(orientation: &Orientation) -> &'static str {
     }
 }
 
-/// The UX8407AA's primary panel (eDP-1) is physically mounted 180° rotated and
-/// KWin does not compensate for the DRM panel-orientation property, so its
-/// rotation must be offset by 180° relative to the secondary panel.
-fn primary_panel_mounted_inverted() -> bool {
-    static FLIPPED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLIPPED.get_or_init(|| {
-        std::fs::read_to_string("/sys/class/dmi/id/board_name")
-            .map(|name| name.trim() == "UX8407AA")
-            .unwrap_or(false)
-    })
-}
+use crate::hardware::duo::primary_panel_mounted_inverted;
 
 fn kde_primary_rotation_token(orientation: &Orientation, panel_inverted: bool) -> &'static str {
     if !panel_inverted {
@@ -192,18 +182,37 @@ fn kde_primary_rotation_token(orientation: &Orientation, panel_inverted: bool) -
 /// Positions for (primary, secondary) in dual-screen mode. KWin does not
 /// reliably apply layouts with negative coordinates, so the pair is always
 /// anchored with the leftmost/topmost output at 0,0.
+///
+/// `primary_size` must be the panel's *unrotated* logical size; the rotation
+/// swap is applied here from the target orientation, so passing an already
+/// rotated size would swap twice and stack the panels along the wrong axis.
+///
+/// When the primary panel is mounted 180° rotated it physically ends up on the
+/// opposite side of the secondary in portrait, so the left/right pair is
+/// mirrored. Stacked (Normal/Inverted) order is unaffected by the mount.
 fn dual_screen_positions(
     orientation: &Orientation,
     primary_size: Result<(i64, i64), String>,
+    panel_inverted: bool,
 ) -> Result<((i64, i64), (i64, i64)), String> {
     let (width, height) = primary_size?;
     let (rot_w, rot_h) = match orientation {
         Orientation::Left | Orientation::Right => (height, width),
         Orientation::Normal | Orientation::Inverted => (width, height),
     };
+    let primary_leads_horizontally = match orientation {
+        Orientation::Left => panel_inverted,
+        Orientation::Right => !panel_inverted,
+        _ => false,
+    };
     Ok(match orientation {
-        Orientation::Left => ((rot_w, 0), (0, 0)),
-        Orientation::Right => ((0, 0), (rot_w, 0)),
+        Orientation::Left | Orientation::Right => {
+            if primary_leads_horizontally {
+                ((0, 0), (rot_w, 0))
+            } else {
+                ((rot_w, 0), (0, 0))
+            }
+        }
         Orientation::Inverted => ((0, rot_h), (0, 0)),
         Orientation::Normal => ((0, 0), (0, rot_h)),
     })
@@ -226,6 +235,7 @@ pub(super) fn set_kde_orientation(orientation: &Orientation) -> Result<(), Strin
     let ((primary_x, primary_y), (secondary_x, secondary_y)) = dual_screen_positions(
         orientation,
         kde_output_logical_size(PRIMARY_INTERNAL_CONNECTOR),
+        primary_panel_mounted_inverted(),
     )?;
 
     let args = vec![
@@ -246,7 +256,8 @@ mod tests {
 
     #[test]
     fn missing_primary_geometry_is_an_error_for_secondary_positioning() {
-        let result = dual_screen_positions(&Orientation::Normal, Err("missing geometry".into()));
+        let result =
+            dual_screen_positions(&Orientation::Normal, Err("missing geometry".into()), false);
 
         assert_eq!(
             result.expect_err("missing geometry should fail"),
@@ -257,21 +268,44 @@ mod tests {
     #[test]
     fn dual_screen_positions_use_rotated_geometry_without_negative_coordinates() {
         assert_eq!(
-            dual_screen_positions(&Orientation::Left, Ok((1200, 800))).expect("positions"),
+            dual_screen_positions(&Orientation::Left, Ok((1200, 800)), false).expect("positions"),
             ((800, 0), (0, 0))
         );
         assert_eq!(
-            dual_screen_positions(&Orientation::Right, Ok((1200, 800))).expect("positions"),
+            dual_screen_positions(&Orientation::Right, Ok((1200, 800)), false).expect("positions"),
             ((0, 0), (800, 0))
         );
         assert_eq!(
-            dual_screen_positions(&Orientation::Inverted, Ok((1200, 800))).expect("positions"),
+            dual_screen_positions(&Orientation::Inverted, Ok((1200, 800)), false)
+                .expect("positions"),
             ((0, 800), (0, 0))
         );
         assert_eq!(
-            dual_screen_positions(&Orientation::Normal, Ok((1200, 800))).expect("positions"),
+            dual_screen_positions(&Orientation::Normal, Ok((1200, 800)), false).expect("positions"),
             ((0, 0), (0, 800))
         );
+    }
+
+    #[test]
+    fn inverted_primary_panel_mirrors_only_the_portrait_pair() {
+        // Measured on UX8407AA: rotating left puts the primary (eDP-1) on the
+        // physical left, the opposite of an ordinarily mounted panel.
+        assert_eq!(
+            dual_screen_positions(&Orientation::Left, Ok((1200, 800)), true).expect("positions"),
+            ((0, 0), (800, 0))
+        );
+        assert_eq!(
+            dual_screen_positions(&Orientation::Right, Ok((1200, 800)), true).expect("positions"),
+            ((800, 0), (0, 0))
+        );
+
+        // Stacked orientations are unaffected by the mount.
+        for orientation in [Orientation::Normal, Orientation::Inverted] {
+            assert_eq!(
+                dual_screen_positions(&orientation, Ok((1200, 800)), true).expect("positions"),
+                dual_screen_positions(&orientation, Ok((1200, 800)), false).expect("positions"),
+            );
+        }
     }
 
     #[test]

--- a/ui-tauri-react/src-tauri/src/hardware/display_layout/kde.rs
+++ b/ui-tauri-react/src-tauri/src/hardware/display_layout/kde.rs
@@ -165,37 +165,65 @@ fn kde_rotation_token(orientation: &Orientation) -> &'static str {
     }
 }
 
-fn rotated_secondary_position(
+/// The UX8407AA's primary panel (eDP-1) is physically mounted 180° rotated and
+/// KWin does not compensate for the DRM panel-orientation property, so its
+/// rotation must be offset by 180° relative to the secondary panel.
+fn primary_panel_mounted_inverted() -> bool {
+    static FLIPPED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLIPPED.get_or_init(|| {
+        std::fs::read_to_string("/sys/class/dmi/id/board_name")
+            .map(|name| name.trim() == "UX8407AA")
+            .unwrap_or(false)
+    })
+}
+
+fn kde_primary_rotation_token(orientation: &Orientation, panel_inverted: bool) -> &'static str {
+    if !panel_inverted {
+        return kde_rotation_token(orientation);
+    }
+    match orientation {
+        Orientation::Left => "left",
+        Orientation::Right => "right",
+        Orientation::Inverted => "none",
+        Orientation::Normal => "inverted",
+    }
+}
+
+/// Positions for (primary, secondary) in dual-screen mode. KWin does not
+/// reliably apply layouts with negative coordinates, so the pair is always
+/// anchored with the leftmost/topmost output at 0,0.
+fn dual_screen_positions(
     orientation: &Orientation,
     primary_size: Result<(i64, i64), String>,
-) -> Result<(i64, i64), String> {
+) -> Result<((i64, i64), (i64, i64)), String> {
     let (width, height) = primary_size?;
     let (rot_w, rot_h) = match orientation {
         Orientation::Left | Orientation::Right => (height, width),
         Orientation::Normal | Orientation::Inverted => (width, height),
     };
     Ok(match orientation {
-        Orientation::Left => (-rot_w, 0),
-        Orientation::Right => (rot_w, 0),
-        Orientation::Inverted => (0, -rot_h),
-        Orientation::Normal => (0, rot_h),
+        Orientation::Left => ((rot_w, 0), (0, 0)),
+        Orientation::Right => ((0, 0), (rot_w, 0)),
+        Orientation::Inverted => ((0, rot_h), (0, 0)),
+        Orientation::Normal => ((0, 0), (0, rot_h)),
     })
 }
 
 pub(super) fn set_kde_orientation(orientation: &Orientation) -> Result<(), String> {
     let token = kde_rotation_token(orientation);
+    let primary_token = kde_primary_rotation_token(orientation, primary_panel_mounted_inverted());
     let enabled_count = kde_enabled_output_count().unwrap_or(1);
 
     if enabled_count <= 1 {
         let args = vec![
             format!("output.{PRIMARY_INTERNAL_CONNECTOR}.enable"),
             format!("output.{PRIMARY_INTERNAL_CONNECTOR}.position.0,0"),
-            format!("output.{PRIMARY_INTERNAL_CONNECTOR}.rotation.{token}"),
+            format!("output.{PRIMARY_INTERNAL_CONNECTOR}.rotation.{primary_token}"),
         ];
         return run_command("kscreen-doctor", &args);
     }
 
-    let (pos_x, pos_y) = rotated_secondary_position(
+    let ((primary_x, primary_y), (secondary_x, secondary_y)) = dual_screen_positions(
         orientation,
         kde_output_logical_size(PRIMARY_INTERNAL_CONNECTOR),
     )?;
@@ -203,10 +231,10 @@ pub(super) fn set_kde_orientation(orientation: &Orientation) -> Result<(), Strin
     let args = vec![
         format!("output.{PRIMARY_INTERNAL_CONNECTOR}.enable"),
         format!("output.{SECONDARY_INTERNAL_CONNECTOR}.enable"),
-        format!("output.{PRIMARY_INTERNAL_CONNECTOR}.rotation.{token}"),
+        format!("output.{PRIMARY_INTERNAL_CONNECTOR}.rotation.{primary_token}"),
         format!("output.{SECONDARY_INTERNAL_CONNECTOR}.rotation.{token}"),
-        format!("output.{PRIMARY_INTERNAL_CONNECTOR}.position.0,0"),
-        format!("output.{SECONDARY_INTERNAL_CONNECTOR}.position.{pos_x},{pos_y}"),
+        format!("output.{PRIMARY_INTERNAL_CONNECTOR}.position.{primary_x},{primary_y}"),
+        format!("output.{SECONDARY_INTERNAL_CONNECTOR}.position.{secondary_x},{secondary_y}"),
     ];
 
     run_command("kscreen-doctor", &args)
@@ -218,8 +246,7 @@ mod tests {
 
     #[test]
     fn missing_primary_geometry_is_an_error_for_secondary_positioning() {
-        let result =
-            rotated_secondary_position(&Orientation::Normal, Err("missing geometry".into()));
+        let result = dual_screen_positions(&Orientation::Normal, Err("missing geometry".into()));
 
         assert_eq!(
             result.expect_err("missing geometry should fail"),
@@ -228,14 +255,54 @@ mod tests {
     }
 
     #[test]
-    fn secondary_position_uses_rotated_primary_geometry() {
+    fn dual_screen_positions_use_rotated_geometry_without_negative_coordinates() {
         assert_eq!(
-            rotated_secondary_position(&Orientation::Left, Ok((1200, 800))).expect("position"),
-            (-800, 0)
+            dual_screen_positions(&Orientation::Left, Ok((1200, 800))).expect("positions"),
+            ((800, 0), (0, 0))
         );
         assert_eq!(
-            rotated_secondary_position(&Orientation::Normal, Ok((1200, 800))).expect("position"),
-            (0, 800)
+            dual_screen_positions(&Orientation::Right, Ok((1200, 800))).expect("positions"),
+            ((0, 0), (800, 0))
+        );
+        assert_eq!(
+            dual_screen_positions(&Orientation::Inverted, Ok((1200, 800))).expect("positions"),
+            ((0, 800), (0, 0))
+        );
+        assert_eq!(
+            dual_screen_positions(&Orientation::Normal, Ok((1200, 800))).expect("positions"),
+            ((0, 0), (0, 800))
+        );
+    }
+
+    #[test]
+    fn primary_rotation_token_matches_secondary_when_panel_is_not_inverted() {
+        for orientation in [
+            Orientation::Normal,
+            Orientation::Inverted,
+            Orientation::Left,
+            Orientation::Right,
+        ] {
+            assert_eq!(
+                kde_primary_rotation_token(&orientation, false),
+                kde_rotation_token(&orientation)
+            );
+        }
+    }
+
+    #[test]
+    fn primary_rotation_token_is_offset_180_when_panel_is_inverted() {
+        assert_eq!(
+            kde_primary_rotation_token(&Orientation::Normal, true),
+            "inverted"
+        );
+        assert_eq!(
+            kde_primary_rotation_token(&Orientation::Inverted, true),
+            "none"
+        );
+        assert_eq!(kde_primary_rotation_token(&Orientation::Left, true), "left");
+        assert_eq!(
+            kde_primary_rotation_token(&Orientation::Right, true),
+            "right"
         );
     }
 }

--- a/ui-tauri-react/src-tauri/src/hardware/duo.rs
+++ b/ui-tauri-react/src-tauri/src/hardware/duo.rs
@@ -15,6 +15,23 @@ pub fn is_secondary_internal_connector(connector: &str) -> bool {
     connector == SECONDARY_INTERNAL_CONNECTOR
 }
 
+/// Boards whose primary panel (eDP-1) is physically mounted 180° rotated.
+/// KWin does not compensate via the DRM panel-orientation property, so the
+/// primary's physical rotation is offset by 180° from the logical orientation,
+/// and the two panels swap sides in portrait.
+fn board_has_inverted_primary_panel(board_name: &str) -> bool {
+    board_name.trim() == "UX8407AA"
+}
+
+pub fn primary_panel_mounted_inverted() -> bool {
+    static FLIPPED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLIPPED.get_or_init(|| {
+        std::fs::read_to_string("/sys/class/dmi/id/board_name")
+            .map(|name| board_has_inverted_primary_panel(&name))
+            .unwrap_or(false)
+    })
+}
+
 pub fn connector_for_elan_name(name: &str) -> Option<&'static str> {
     if name.contains("ELAN9008") {
         Some(PRIMARY_INTERNAL_CONNECTOR)
@@ -34,6 +51,14 @@ mod tests {
         assert!(is_internal_connector(PRIMARY_INTERNAL_CONNECTOR));
         assert!(is_internal_connector(SECONDARY_INTERNAL_CONNECTOR));
         assert!(!is_internal_connector("HDMI-A-1"));
+    }
+
+    #[test]
+    fn only_ux8407aa_reports_an_inverted_primary_panel() {
+        assert!(board_has_inverted_primary_panel("UX8407AA"));
+        assert!(board_has_inverted_primary_panel("UX8407AA\n"));
+        assert!(!board_has_inverted_primary_panel("UX8406MA"));
+        assert!(!board_has_inverted_primary_panel(""));
     }
 
     #[test]

--- a/ui-tauri-react/src-tauri/src/runtime/compositor.rs
+++ b/ui-tauri-react/src-tauri/src/runtime/compositor.rs
@@ -97,11 +97,25 @@ pub fn kde_output_logical_size_from_value(value: &Value, name: &str) -> Result<(
                 .and_then(|v| v.as_object())
                 .ok_or_else(|| "Missing KDE output size".to_string())?;
             let scale = output.get("scale").and_then(|v| v.as_f64()).unwrap_or(1.0);
-            let width = size.get("width").and_then(|v| v.as_i64()).unwrap_or(0);
-            let height = size.get("height").and_then(|v| v.as_i64()).unwrap_or(0);
+            let mut width = size.get("width").and_then(|v| v.as_i64()).unwrap_or(0);
+            let mut height = size.get("height").and_then(|v| v.as_i64()).unwrap_or(0);
+
+            // KWin reports `size` already rotated (a 2880x1800 panel reads back
+            // as 1800x2880 at 90/270), so undo that here and always return the
+            // panel's unrotated logical size. Callers apply their own rotation
+            // swap from the orientation they are about to set; without this the
+            // swap happens twice and a width is used as a vertical offset.
+            if matches!(output.get("rotation").and_then(|v| v.as_i64()), Some(2) | Some(8)) {
+                std::mem::swap(&mut width, &mut height);
+            }
+
+            // KWin derives logical sizes by rounding up, so mirror ceil here.
+            // Rounding down leaves a one-pixel seam between stacked panels on
+            // fractional scales (1800 / 1.6583 = 1085.43 -> 1085 vs KWin's 1086),
+            // which KDE reports as a gap and blocks pointer movement across it.
             return Ok((
-                (width as f64 / scale).round() as i64,
-                (height as f64 / scale).round() as i64,
+                (width as f64 / scale).ceil() as i64,
+                (height as f64 / scale).ceil() as i64,
             ));
         }
     }
@@ -185,6 +199,44 @@ mod tests {
             Ok((1920, 1200))
         );
         assert_eq!(kde_enabled_output_count_from_value(&value), Ok(1));
+    }
+
+    #[test]
+    fn fractional_scale_logical_size_rounds_up_to_match_kwin() {
+        // UX8407AA panels at the default 1.66 scale: 1800 / 1.6583 = 1085.43.
+        // KWin reports 1086, so rounding down would stack the second panel one
+        // pixel short and leave a gap the pointer cannot cross.
+        let value = serde_json::json!({
+            "outputs": [
+                { "name": "eDP-1", "enabled": true, "size": { "width": 2880, "height": 1800 }, "scale": 1.6583333333333334 }
+            ]
+        });
+
+        assert_eq!(
+            kde_output_logical_size_from_value(&value, "eDP-1"),
+            Ok((1737, 1086))
+        );
+    }
+
+    #[test]
+    fn rotated_outputs_report_their_unrotated_logical_size() {
+        // KWin reports `size` already rotated at 90/270. Returning it as-is made
+        // callers swap a second time and stack panels along the wrong axis.
+        let value = serde_json::json!({
+            "outputs": [
+                { "name": "eDP-1", "enabled": true, "rotation": 8, "size": { "width": 1800, "height": 2880 }, "scale": 1.6583333333333334 },
+                { "name": "eDP-2", "enabled": true, "rotation": 1, "size": { "width": 2880, "height": 1800 }, "scale": 1.6583333333333334 }
+            ]
+        });
+
+        assert_eq!(
+            kde_output_logical_size_from_value(&value, "eDP-1"),
+            Ok((1737, 1086))
+        );
+        assert_eq!(
+            kde_output_logical_size_from_value(&value, "eDP-2"),
+            kde_output_logical_size_from_value(&value, "eDP-1")
+        );
     }
 
     #[test]

--- a/ui-tauri-react/src-tauri/src/runtime/daemon.rs
+++ b/ui-tauri-react/src-tauri/src/runtime/daemon.rs
@@ -673,7 +673,7 @@ fn queue_lid_display_retry(state: Arc<RwLock<RuntimeState>>, lid_closed: bool) {
     });
 }
 
-fn queue_lifecycle_display_retry(state: Arc<RwLock<RuntimeState>>) {
+pub(crate) fn queue_lifecycle_display_retry(state: Arc<RwLock<RuntimeState>>) {
     tokio::spawn(async move {
         const RETRY_ATTEMPTS: usize = 6;
         const RETRY_DELAY: Duration = Duration::from_secs(1);

--- a/ui-tauri-react/src-tauri/src/runtime/monitor.rs
+++ b/ui-tauri-react/src-tauri/src/runtime/monitor.rs
@@ -276,17 +276,25 @@ async fn apply_policy_actions(state: Arc<RwLock<RuntimeState>>, actions: Vec<Pol
                     crate::runtime::daemon::replay_current_display_mode(&state, attached, scale)
                         .await
                 {
-                    log::warn!("failed to apply display-mode policy action: {err}");
-                    crate::runtime::daemon::notify_runtime_error(
-                        &state,
-                        "Zenbook Duo Runtime Error",
-                        &format!("Display-mode policy action failed: {err}"),
-                    )
-                    .await;
-                    let _ = logger::append_line(format!(
-                        "rust-daemon: display-mode policy action failed (attached={}, scale={}): {}",
-                        attached, scale, err
-                    ));
+                    if crate::runtime::daemon::is_display_session_deferral(&err) {
+                        let _ = logger::append_line(format!(
+                            "rust-daemon: display-mode policy action deferred (attached={}, scale={}): {}",
+                            attached, scale, err
+                        ));
+                        crate::runtime::daemon::queue_lifecycle_display_retry(state.clone());
+                    } else {
+                        log::warn!("failed to apply display-mode policy action: {err}");
+                        crate::runtime::daemon::notify_runtime_error(
+                            &state,
+                            "Zenbook Duo Runtime Error",
+                            &format!("Display-mode policy action failed: {err}"),
+                        )
+                        .await;
+                        let _ = logger::append_line(format!(
+                            "rust-daemon: display-mode policy action failed (attached={}, scale={}): {}",
+                            attached, scale, err
+                        ));
+                    }
                 } else {
                     let _ = logger::append_line(format!(
                         "rust-daemon: applied display-mode policy action (attached={}, scale={})",

--- a/ui-tauri-react/src-tauri/src/runtime/probe.rs
+++ b/ui-tauri-react/src-tauri/src/runtime/probe.rs
@@ -18,8 +18,23 @@ pub fn current_status() -> DuoStatus {
 }
 
 pub fn apply_layout_to_status(status: &mut DuoStatus, layout: Option<&DisplayLayout>) {
+    apply_layout_to_status_with(
+        status,
+        layout,
+        crate::hardware::duo::primary_panel_mounted_inverted(),
+    );
+}
+
+/// Hardware probing stays at the edge so the mapping itself remains testable
+/// without depending on the DMI of the machine running the tests.
+pub(crate) fn apply_layout_to_status_with(
+    status: &mut DuoStatus,
+    layout: Option<&DisplayLayout>,
+    mounted_inverted: bool,
+) {
     status.monitor_count = monitor_count(layout, status.monitor_count);
-    status.orientation = inferred_orientation(layout).unwrap_or(status.orientation.clone());
+    status.orientation =
+        inferred_orientation(layout, mounted_inverted).unwrap_or(status.orientation.clone());
 }
 
 pub fn keyboard_attached(connection_type: &ConnectionType) -> bool {
@@ -58,7 +73,10 @@ fn monitor_count(layout: Option<&crate::models::DisplayLayout>, current: u32) ->
         .unwrap_or(0)
 }
 
-fn inferred_orientation(layout: Option<&crate::models::DisplayLayout>) -> Option<Orientation> {
+fn inferred_orientation(
+    layout: Option<&crate::models::DisplayLayout>,
+    mounted_inverted: bool,
+) -> Option<Orientation> {
     let layout = layout?;
     let display = layout
         .displays
@@ -66,17 +84,56 @@ fn inferred_orientation(layout: Option<&crate::models::DisplayLayout>) -> Option
         .find(|display| display.primary)
         .or_else(|| layout.displays.first())?;
 
-    Some(match display.transform {
+    let inverted = mounted_inverted
+        && crate::hardware::duo::is_primary_internal_connector(&display.connector);
+
+    Some(orientation_from_transform(display.transform, inverted))
+}
+
+/// Inverse of the rotation tokens the display backends apply. On boards whose
+/// primary panel is mounted 180° rotated its physical transform is offset by
+/// 180° from the logical orientation, so reading it back naively reports an
+/// upright screen as `Inverted`; replaying that value then flips the panel and
+/// the next probe reports `Normal`, which is what makes the rotation oscillate.
+fn orientation_from_transform(transform: u32, mounted_inverted: bool) -> Orientation {
+    if mounted_inverted {
+        return match transform {
+            90 => Orientation::Right,
+            180 => Orientation::Normal,
+            270 => Orientation::Left,
+            _ => Orientation::Inverted,
+        };
+    }
+
+    match transform {
         90 => Orientation::Left,
         180 => Orientation::Inverted,
         270 => Orientation::Right,
         _ => Orientation::Normal,
-    })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inverted_primary_panel_reads_back_as_the_logical_orientation() {
+        // Physical 180 on an inverted-mount primary is logically upright.
+        // Reporting it as Inverted let a replay flip the panel and oscillate.
+        assert_eq!(orientation_from_transform(180, true), Orientation::Normal);
+        assert_eq!(orientation_from_transform(0, true), Orientation::Inverted);
+        assert_eq!(orientation_from_transform(90, true), Orientation::Right);
+        assert_eq!(orientation_from_transform(270, true), Orientation::Left);
+    }
+
+    #[test]
+    fn ordinary_panels_keep_the_existing_orientation_mapping() {
+        assert_eq!(orientation_from_transform(0, false), Orientation::Normal);
+        assert_eq!(orientation_from_transform(90, false), Orientation::Left);
+        assert_eq!(orientation_from_transform(180, false), Orientation::Inverted);
+        assert_eq!(orientation_from_transform(270, false), Orientation::Right);
+    }
 
     #[test]
     fn reads_radio_status_through_host_adapter() {
@@ -181,9 +238,15 @@ mod tests {
             ],
         };
 
-        apply_layout_to_status(&mut status, Some(&layout));
+        apply_layout_to_status_with(&mut status, Some(&layout), false);
 
         assert_eq!(status.orientation, Orientation::Left);
         assert_eq!(status.monitor_count, 2);
+
+        // Same physical transform on an inverted-mount primary is the opposite
+        // logical orientation.
+        apply_layout_to_status_with(&mut status, Some(&layout), true);
+
+        assert_eq!(status.orientation, Orientation::Right);
     }
 }

--- a/ui-tauri-react/src-tauri/src/runtime/session_agent/rotation.rs
+++ b/ui-tauri-react/src-tauri/src/runtime/session_agent/rotation.rs
@@ -218,11 +218,15 @@ pub(super) fn display_orientation_from_sensor_value(
 fn runtime_log_info(message: impl AsRef<str>) {
     let text = message.as_ref();
     let _ = crate::runtime::logger::append_line(format!("session-agent: {text}"));
+    // The daemon log file is often not writable from the user session, so also
+    // emit to stderr where the systemd user journal captures it.
+    eprintln!("session-agent: {text}");
     log::info!("{text}");
 }
 
 fn runtime_log_warn(message: impl AsRef<str>) {
     let text = message.as_ref();
     let _ = crate::runtime::logger::append_line(format!("session-agent: {text}"));
+    eprintln!("session-agent: {text}");
     log::warn!("{text}");
 }


### PR DESCRIPTION
Added compatibility for the ASUS Zenbook Duo 2026.

What works so far:

* Screen orientation
* Keyboard connection and reconnection
* Audio
* Brightness control

What doesn’t work:

* Virtual machines


Kernel patches are sourced from:
https://github.com/therealarnold666/zenbook-duo26-Ubuntu26.04

Credits to the original author for the kernel patches.


Demo (Video):
https://github.com/user-attachments/assets/0b9296d6-f2b4-46a2-83c3-6b92649c29e6